### PR TITLE
fix: use cookies as session_id for odoo version 17.0.20240610 and above

### DIFF
--- a/src/OdooJSONRpc.ts
+++ b/src/OdooJSONRpc.ts
@@ -133,6 +133,7 @@ export default class OdooJSONRpc {
     const headers: any = {
       'Content-Type': 'application/json',
       'X-Openerp-Session-Id': this.session_id,
+      'Cookie': `session_id=${this.session_id}`,
     };
     const [response, request_error] = await Try(() =>
       fetch(endpoint, {
@@ -172,6 +173,7 @@ export default class OdooJSONRpc {
           headers: {
             'Content-Type': 'application/json',
             'X-Openerp-Session-Id': this.session_id,
+            'Cookie': `session_id=${this.session_id}`,
           },
           body: JSON.stringify(data),
         })


### PR DESCRIPTION
note: a new security update where `X-Openerp-Session-Id` no longer works for new versions

The session_id may only be provided via the cookies in the header of the request [Related odoo commit odoo/odoo@64bcffd](https://github.com/odoo/odoo/commit/64bcffd5ab9e4048c7115df243a0c29b8965cec9).