### PR TITLE
fix: cannot use 'in' operator to search for 'username'

### DIFF
--- a/src/OdooJSONRpc.ts
+++ b/src/OdooJSONRpc.ts
@@ -128,7 +128,7 @@ export const Try = async <T>(fn: () => Promise<T>): Promise<[T, null] | [null, E
 export const isCredentialsResponse = (
   response: OdooAuthenticateWithCredentialsResponse | OdooAuthenticateWithApiKeyResponse
 ): response is OdooAuthenticateWithCredentialsResponse => {
-  return 'username' in response;
+  return response && 'username' in response;
 };
 export default class OdooJSONRpc {
   public url: string | undefined = undefined;


### PR DESCRIPTION
If the sessionId wrong the response be undefined and fire an error
```batch
TypeError: Cannot use 'in' operator to search for 'username' in undefined
```

Solve this issue #6 