### PR TITLE
Add way to update translations of fields values

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -392,6 +392,16 @@ const records = await odoo.searchRead(`res.partner`, [], ['name', 'city'], {
 });
 ```
 
+#### odoo.updateFieldTranslations(model, id, field, translations)
+
+Updates the translations of a specific field.
+Translations needs to be an Object with keys as languages and values as translations.
+
+```js
+const result = await odoo.updateFieldTranslations(`product.template`, 1, `name`, { de_DE: 'Neuer Name', en_GB: 'New name' })
+console.log(result) // true if it was successful
+```
+
 #### Complex domain filters
 
 A domain filter array can be supplied if any of the alternate domain filters are needed, such as

--- a/src/OdooJSONRpc.ts
+++ b/src/OdooJSONRpc.ts
@@ -437,6 +437,16 @@ export default class OdooJSONRpc {
   async update(model: string, id: number, values: any): Promise<boolean> {
     return this.call_kw(model, 'write', [[id], values]);
   }
+  /**
+   * Updates the translations for a field in the specified Odoo model.
+   * @param model Model to update eg. product.template
+   * @param id Id of the model to update
+   * @param field field to update eg. name
+   * @param translations object with translations eg. {de_DE: "Neuer Name", en_GB: "Name"}
+   */
+  async updateFieldTranslations(model: string, id: number, field: string, translations: { [key: string]: string }) {
+    return this.call_kw(model, "update_field_translations", [[id], field, translations]);
+  }
   //Deletes a record from the specified Odoo model.
   async delete(model: string, id: number): Promise<boolean> {
     return this.call_kw(model, 'unlink', [[id]]);


### PR DESCRIPTION
This adds the updateFieldTranslations function.
Since Odoo 16 translations changed from the ir.translations object.

This is undocumented behavior, but I reverse engineered it from the web app as I need it for a use case.

The resources I found online telling me to translate with the regular update method using an object didn't work for me.
Example:
product.template
`name: { de_DE: 'new name', en_GB: 'new name' }`

How to use:

`api.updateFieldTranslations('product.template', 1, 'name', { de_DE: 'new name', en_GB: 'new name' })`
